### PR TITLE
Make `pyright` happy again

### DIFF
--- a/etl_tnl_alert.py
+++ b/etl_tnl_alert.py
@@ -12,7 +12,7 @@ from pyspark.sql import SparkSession
 
 # for our purposes here, the spark and glue context are only (currently) needed
 # to get the logger.
-spark_ctx = SparkSession.builder.getOrCreate()
+spark_ctx = SparkSession.builder.getOrCreate()  # pyright: ignore
 glue_ctx = GlueContext(spark_ctx)
 logger = glue_ctx.get_logger()
 


### PR DESCRIPTION
This does a couple things:

- fix: use `iloc` rather than chained indexing as this is more correct
- fix: disables type checking on the pyspark line as it's not an issue but the result of a bug in the upstream code (https://github.com/apache/spark/pull/45700)