### PR TITLE
fix: update to capepy v2

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ OUT_COL_NAMES = [
 #       - a 1 column header row that can be ignored
 #       - another header row that contains all the column names for the table
 #       - rows of data
-data = pd.read_excel(etl_job.get_raw_file(), engine="openpyxl", skiprows=1)
+data = pd.read_excel(etl_job.get_src_file(), engine="openpyxl", skiprows=1)
 
 # strip out the ingorable header and reset the index
 data[1:].reset_index(drop=True, inplace=True)
@@ -118,7 +118,7 @@ interim["State_Lab_ID"] = data["State_Lab_ID"]
 # write out the transformed data
 with io.StringIO() as csv_buff:
     interim.to_csv(csv_buff, index=False)
-    etl_job.write_clean_file(
+    etl_job.write_sink_file(
         csv_buff.getvalue(),
         etl_job.parameters["OBJECT_KEY"].replace(".xlsx", ".csv"),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aws-glue-libs @ git+https://github.com/awslabs/aws-glue-libs@9d8293962e6ffc607e5dc328e246f40b24010fa8
 boto3==1.34.103
-capepy>=1.0.0,<2.0.0
+capepy>=2.0.0,<3.0.0
 pandas==2.2.2
 pyspark==3.5.1


### PR DESCRIPTION
This updates the ETL script to use the latest tooling from the `capepy` library which recently had a refactor to generalize the names of some of the functions